### PR TITLE
Edit the elec_jackhammer power drain

### DIFF
--- a/data/json/items/tools.json
+++ b/data/json/items/tools.json
@@ -3056,7 +3056,7 @@
     "symbol": ";",
     "color": "light_gray",
     "ammo": "battery",
-    "charges_per_use": 25,
+    "charges_per_use": 250,
     "use_action": "JACKHAMMER",
     "flags": [ "STAB", "DIG_TOOL", "POWERED" ],
     "magazines": [


### PR DESCRIPTION
```SUMMARY: Balance "Increase the power requirements for elec_jackhammer"```

#### Purpose of change

Currently the electric jackhammer drains 25 charges per operation, that can last for up to an hour. This is about the same as the flashlight drains, if not less, despite the jackhammer being a piece of heavy equipment.

#### Describe the solution

Upping the power requirement _at least_ ten times will probably be a bit closer to the reality.

#### Describe alternatives you've considered

- Upping the drain to 500 or 100 charges would be much better, but this won't fit cleanly with the existing battery cells, with 250 one can drain the cell dry after a couple uses, with no charges left.
- Changing the battery capacity to be cleanly divided by 500 or 1000, then changing the jackhammer's drain to those values.
- Actually making the jackhammer drain 1 power per X turns, though I'm not sure how to do this and how it will work out.